### PR TITLE
docs(may-2021): add "What is Missing before the Release"

### DIFF
--- a/content/blog/what-happened-on-may-2021-for-leon/index.md
+++ b/content/blog/what-happened-on-may-2021-for-leon/index.md
@@ -95,7 +95,16 @@ Now that you know more about what has been done until now, I will let Arthur exp
 
 ### What is Missing Before the Release
 
-👋 [Arthur](https://github.com/ArthurDelamare)...
+👋 [Arthur](https://github.com/ArthurDelamare), Passionate Developer and newly wed to open-source contributions.
+
+The CLI progress is right on track and we are that close to reach our goal. Before the release, here is what's left:
+- Achieve the Python requirement for our fellow Unix users, the last component to be done.
+- Put the individual components together.
+- Write the end-to-end tests to ensure no regression will happen.
+
+After that, both classic and Docker installations will be ready to be used.
+
+I hope you'll enjoy using it as much as we enjoyed doing it!
 
 ## Road to React
 


### PR DESCRIPTION
Introduce the "What is Missing before the Release" part about Leon CLI for may 2021 blog post.

If there's anything to adjust, do not hesitate to tell me.