### PR TITLE
dark scrollbar in Chrome on Windows

### DIFF
--- a/src/style.sass
+++ b/src/style.sass
@@ -69,6 +69,8 @@
 :before 
   box-sizing: border-box
 
+\:root
+  color-scheme: dark
 
 html 
   line-height: var(--lineHeight-normal)


### PR DESCRIPTION
to match the black background